### PR TITLE
NVME_QUIRK_NO_DEEPEST_PS for Kingston A2000

### DIFF
--- a/NVMeFix/nvme_quirks.cpp
+++ b/NVMeFix/nvme_quirks.cpp
@@ -112,6 +112,8 @@ static constexpr struct pci_device_id nvme_id_table[] = {
 	{ 0x1cc1, 0x8201,   /* ADATA SX8200PNP 512GB */
 		NVME_QUIRK_NO_DEEPEST_PS |
 				NVME_QUIRK_IGNORE_DEV_SUBNQN, },
+	{ 0x2646, 0x2263,   /* Kingston A2000 */
+		NVME_QUIRK_NO_DEEPEST_PS, },
 
 	/* Should be taken care of by IONVMeFamily */
 #if 0


### PR DESCRIPTION
Apparently Kingston A2000 has APST issues.

[Kernel-2021-02-27-144115.panic.zip](https://github.com/acidanthera/NVMeFix/files/6061642/Kernel-2021-02-27-144115.panic.zip)

Looks like the same problem described here:

> Some Kingston A2000 NVMe SSDs sooner or later get confused and stop
working when they use the deepest APST sleep while running Linux. The
system then crashes and one has to cold boot it to get the SSD working
again.

[https://lore.kernel.org/linux-nvme/20210129052442.310780-1-linux@leemhuis.info/](https://lore.kernel.org/linux-nvme/20210129052442.310780-1-linux@leemhuis.info/)
