### PR TITLE
Don't use strcmp with null padded, non-zero padded buffers

### DIFF
--- a/NVMeFix/nvme_quirks.hpp
+++ b/NVMeFix/nvme_quirks.hpp
@@ -135,8 +135,10 @@ constexpr nvme_quirks operator&=(T& a, T b) {
 	return a;
 }
 
+using mn_ref_t = const char(&)[40];
+using fr_ref_t = const char(&)[8];
 nvme_quirks quirksForController(IOService*);
-nvme_quirks quirksForController(uint16_t,const char*,const char*);
+nvme_quirks quirksForController(uint16_t,mn_ref_t,fr_ref_t);
 }
 
 template <typename T>


### PR DESCRIPTION
```strcmp``` will only return ```0``` if there is NULL in the same position in non-zero padded ```char[8]``` ```fr``` as ```char*``` ```entry.fr```. 

So
```
!entry.fr || !strcmp(entry.fr, fr)
``` 
will always be false
