### PR TITLE
Make Kingston A2000 quirk specific to S5Z42105

### DIFF
--- a/NVMeFix/nvme_quirks.cpp
+++ b/NVMeFix/nvme_quirks.cpp
@@ -112,8 +112,6 @@ static constexpr struct pci_device_id nvme_id_table[] = {
 	{ 0x1cc1, 0x8201,   /* ADATA SX8200PNP 512GB */
 		NVME_QUIRK_NO_DEEPEST_PS |
 				NVME_QUIRK_IGNORE_DEV_SUBNQN, },
-	{ 0x2646, 0x2263,   /* Kingston A2000 */
-		NVME_QUIRK_NO_DEEPEST_PS, },
 
 	/* Should be taken care of by IONVMeFamily */
 #if 0
@@ -317,7 +315,18 @@ static const struct nvme_core_quirk_entry core_quirks[] = {
 		nullptr,
 		"E8FK11",
 		NVME_QUIRK_SIMPLE_SUSPEND,
-	}
+	},
+	{
+		/*
+		 * Kingston A2000 devices with 5Z42105 firmware can become
+		 * unresponsive after entering the deepest power state
+		 * https://lore.kernel.org/linux-nvme/20210129052442.310780-1-linux@leemhuis.info/
+		 */
+		0x2646,
+		nullptr,
+		"S5Z42105",
+		NVME_QUIRK_NO_DEEPEST_PS,
+	},
 };
 
 template <size_t S>


### PR DESCRIPTION
Kingston released firmware revision S5Z42109 for these drives. In the release notes:

```
Fixed an issue that might cause the drive to become unresponsive on Linux systems
```

The quirk entry in this commit matches revision ```S5Z42105``` (which is mentioned on the internet in relation to this issue, and confirmed affected by myself).

There are also (at least 2 other) firmware versions ```S5Z42102``` and ```S5Z42103```.  I've not confirmed whether or not these  are affected.
